### PR TITLE
boards: mr_mcxn_t1: Fix Copyright notice

### DIFF
--- a/boards/nxp/mr_mcxn_t1/Kconfig.mr_mcxn_t1
+++ b/boards/nxp/mr_mcxn_t1/Kconfig.mr_mcxn_t1
@@ -1,4 +1,4 @@
-# Copyright 2024 NXP
+# Copyright (c) 2024-2025 NXP
 # SPDX-License-Identifier: Apache-2.0
 
 config BOARD_MR_MCXN_T1

--- a/boards/nxp/mr_mcxn_t1/board.cmake
+++ b/boards/nxp/mr_mcxn_t1/board.cmake
@@ -1,5 +1,5 @@
 #
-# Copyright 2024 NXP
+# Copyright (c) 2024-2025 NXP
 #
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/boards/nxp/mr_mcxn_t1/mr_mcxn_t1-pinctrl.dtsi
+++ b/boards/nxp/mr_mcxn_t1/mr_mcxn_t1-pinctrl.dtsi
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 NXP
+ * Copyright (c) 2024-2025 NXP
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/boards/nxp/mr_mcxn_t1/mr_mcxn_t1_mcxn947_cpu0.dtsi
+++ b/boards/nxp/mr_mcxn_t1/mr_mcxn_t1_mcxn947_cpu0.dtsi
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 NXP
+ * Copyright (c) 2024-2025 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/boards/nxp/mr_mcxn_t1/mr_mcxn_t1_mcxn947_cpu0.yaml
+++ b/boards/nxp/mr_mcxn_t1/mr_mcxn_t1_mcxn947_cpu0.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2024 NXP
+# Copyright (c) 2024-2025 NXP
 #
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/boards/nxp/mr_mcxn_t1/mr_mcxn_t1_mcxn947_cpu1.dts
+++ b/boards/nxp/mr_mcxn_t1/mr_mcxn_t1_mcxn947_cpu1.dts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 NXP
+ * Copyright (c) 2024-2025 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/boards/nxp/mr_mcxn_t1/mr_mcxn_t1_mcxn947_cpu1.yaml
+++ b/boards/nxp/mr_mcxn_t1/mr_mcxn_t1_mcxn947_cpu1.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2024 NXP
+# Copyright (c) 2024-2025 NXP
 #
 # SPDX-License-Identifier: Apache-2.0
 #


### PR DESCRIPTION
Updating NXP copyright header to be 2024-2025.