### PR TITLE
bsp: Changes to enable PAA3905

### DIFF
--- a/boards/nxp/mr_mcxn_t1/mr_mcxn_t1-pinctrl.dtsi
+++ b/boards/nxp/mr_mcxn_t1/mr_mcxn_t1-pinctrl.dtsi
@@ -85,9 +85,9 @@
 	pinmux_flexcomm9_lpspi: pinmux_flexcomm9_lpspi {
 		group0 {
 			pinmux = <FC9_P0_PIO2_4>,
-				<FC9_P1_PIO2_3>,
-				<FC9_P2_PIO2_5>;
-				/*<FC9_P3_PIO2_2>; CS */
+				 <FC9_P1_PIO2_3>,
+				 <FC9_P2_PIO2_5>,
+				 <FC9_P3_PIO2_2>;
 			slew-rate = "fast";
 			drive-strength = "low";
 			input-enable;

--- a/boards/nxp/mr_mcxn_t1/mr_mcxn_t1.dtsi
+++ b/boards/nxp/mr_mcxn_t1/mr_mcxn_t1.dtsi
@@ -149,17 +149,15 @@
 &flexcomm9_lpspi9 {
 	pinctrl-0 = <&pinmux_flexcomm9_lpspi>;
 	pinctrl-names = "default";
-	pcs-sck-delay = <50>;
-	sck-pcs-delay = <50>;
-	transfer-delay = <50>;
-
-	cs-gpios = <&gpio2 2 GPIO_ACTIVE_LOW>;
 
 	paa3905: paa3905@0 {
 		compatible = "pixart,paa3905";
 		reg = <0>;
 		spi-max-frequency = <DT_FREQ_M(10)>;
-		int-gpios = <&gpio3 18 GPIO_ACTIVE_HIGH>;
+		spi-cs-setup-delay-ns = <50>;
+		spi-cs-hold-delay-ns = <50>;
+		spi-interframe-delay-ns = <50>;
+		int-gpios = <&gpio2 0 GPIO_ACTIVE_LOW>;
 		/*led-control;*/
 	};
 


### PR DESCRIPTION
- Fix int-gpios and polarity.
- Use SPI with Hardware CS.