### PR TITLE
boards: mcxn-t1: Add I3C BMM350 performance workaround

### DIFF
--- a/boards/nxp/mr_mcxn_t1/Kconfig.defconfig
+++ b/boards/nxp/mr_mcxn_t1/Kconfig.defconfig
@@ -14,4 +14,6 @@ config MAIN_STACK_SIZE
 
 endif
 
+rsource "Kconfig.i3c_workaround"
+
 endif

--- a/boards/nxp/mr_mcxn_t1/Kconfig.i3c_workaround
+++ b/boards/nxp/mr_mcxn_t1/Kconfig.i3c_workaround
@@ -1,0 +1,13 @@
+config MCXN_T1_I3C_WORKAROUND
+	bool "Enable I3C workaround"
+	default y
+	select USB_DEVICE_STACK_NEXT
+	select CDC_ACM_SERIAL_INITIALIZE_AT_BOOT
+	select SERIAL
+	select CONSOLE
+	select UART_CONSOLE
+	select UART_LINE_CTRL
+	imply I2C
+
+configdefault USBD_CDC_ACM_LOG_LEVEL
+	default 0

--- a/boards/nxp/mr_mcxn_t1/i3c_workaround.dtsi
+++ b/boards/nxp/mr_mcxn_t1/i3c_workaround.dtsi
@@ -1,0 +1,45 @@
+/* Due to the I3C performance issue on BMM350, we're going with
+ * I2C native + USB CDC ACM for console.
+ * Scrub when I3C issue is resolved.
+ */
+
+&i3c0 {
+	status = "disabled";
+};
+
+&flexcomm1_lpuart1 {
+	status = "disabled";
+};
+
+/delete-node/&bmm350_0;
+/delete-node/&bmp581_0;
+
+&flexcomm1_lpi2c1 {
+	status = "okay";
+	pinctrl-0 = <&pinmux_flexcomm1_lpi2c>;
+	pinctrl-names = "default";
+	clock-frequency = <I2C_BITRATE_STANDARD>;
+
+	bmm350_0: bmm350_0@14  {
+		compatible = "bosch,bmm350";
+		reg = <0x14>;
+		odr = "100";
+		drdy-gpios = <&gpio0 19 GPIO_ACTIVE_HIGH>;
+		push-pull-int;
+		active-high-int;
+	};
+};
+
+/ {
+	chosen {
+		zephyr,console = &snippet_cdc_acm_console_uart;
+		zephyr,shell-uart = &snippet_cdc_acm_console_uart;
+		zephyr,uart-mcumgr = &snippet_cdc_acm_console_uart;
+	};
+};
+
+&zephyr_udc0 {
+	snippet_cdc_acm_console_uart: snippet_cdc_acm_console_uart {
+		compatible = "zephyr,cdc-acm-uart";
+	};
+};

--- a/boards/nxp/mr_mcxn_t1/mr_mcxn_t1-pinctrl.dtsi
+++ b/boards/nxp/mr_mcxn_t1/mr_mcxn_t1-pinctrl.dtsi
@@ -17,6 +17,18 @@
 		};
 	};
 
+	pinmux_flexcomm1_lpi2c: pinmux_flexcomm1_lpi2c {
+		group0 {
+			pinmux = <FC1_P0_PIO0_20>,
+				 <FC1_P1_PIO0_21>;
+			slew-rate = "fast";
+			drive-strength = "low";
+			input-enable;
+			bias-pull-up;
+			drive-open-drain;
+		};
+	};
+
 	/* Optical Flow Board */
 	pinmux_flexcomm3_lpspi: pinmux_flexcomm3_lpspi {
 		group0 {

--- a/boards/nxp/mr_mcxn_t1/mr_mcxn_t1.dtsi
+++ b/boards/nxp/mr_mcxn_t1/mr_mcxn_t1.dtsi
@@ -40,6 +40,26 @@
 	pinctrl-names = "default";
 };
 
+&i3c0 {
+	status = "okay";
+	pinctrl-0 = <&pinmux_i3c0>;
+	pinctrl-names = "default";
+	i2c-scl-hz = <400000>;
+
+	bmp581_0: bmp581_0@470000000000000050  {
+		compatible = "bosch,bmp581";
+		reg = <0x47 0x0 0x50>;
+	};
+
+	bmm350_0: bmm350_0@140000000000000050  {
+		compatible = "bosch,bmm350";
+		reg = <0x14 0x0 0x50>;
+		drdy-gpios = <&gpio0 19 GPIO_ACTIVE_HIGH>;
+		push-pull-int;
+		active-high-int;
+	};
+};
+
 /* Optical Flow Board */
 &flexcomm3_lpspi3 {
 	pinctrl-0 = <&pinmux_flexcomm3_lpspi>;
@@ -232,22 +252,6 @@
 		reg = <0x12>;
 		int-gpios = <&gpio1 19 GPIO_ACTIVE_LOW>;
 		master-slave = "auto";
-	};
-};
-
-&i3c0 {
-	pinctrl-0 = <&pinmux_i3c0>;
-	pinctrl-names = "default";
-	i2c-scl-hz = <400000>;
-
-	bmp581_0: bmp581_0@470000000000000050  {
-		compatible = "bosch,bmp581";
-		reg = <0x47 0x0 0x50>;
-	};
-
-	bmm350_0: bmm350_0@140000000000000050  {
-		compatible = "bosch,bmm350";
-		reg = <0x14 0x0 0x50>;
 	};
 };
 

--- a/boards/nxp/mr_mcxn_t1/mr_mcxn_t1_mcxn947_cpu0.dtsi
+++ b/boards/nxp/mr_mcxn_t1/mr_mcxn_t1_mcxn947_cpu0.dtsi
@@ -192,10 +192,8 @@ zephyr_udc0: &usb1 {
 	status = "okay"; /* Locks-up on startup with busy wait */
 };
 
-&bmp581_0 {
-	status = "disabled"; /* Locks-up on startup with busy wait */
-};
-
 &rtc {
 	status = "okay";
 };
+
+#include "i3c_workaround.dtsi"


### PR DESCRIPTION
It's been observed that BMM350's performance is impacted severely when using I3C instead of I2C (even with fallback-mode). The issue needs to be investigated, for now fallback to native i2c.